### PR TITLE
Added User Meta Endpoints

### DIFF
--- a/lib/class-wp-rest-meta-users-controller.php
+++ b/lib/class-wp-rest-meta-users-controller.php
@@ -36,20 +36,13 @@ class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function get_items_permissions_check( $request ) {
-		$parent = get_user_by( 'id', (int) $request['parent_id'] );
+		$user = get_user_by( 'id', (int) $request['parent_id'] );
 
-		if ( empty( $parent ) || empty( $parent->ID ) ) {
+		if ( empty( $user ) || empty( $user->ID ) ) {
 			return new WP_Error( 'rest_user_invalid_id', __( 'Invalid user id.' ), array( 'status' => 404 ) );
 		}
 
-		/* @todo Add a new check to read user
-
-		if ( ! $this->parent_controller->check_read_permission( $parent ) ) {
-			return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view this user.' ), array( 'status' => rest_authorization_required_code() ) );
-		}
-		*/
-
-		if ( ! current_user_can( 'edit_user', $parent->ID ) ) {
+		if ( ! current_user_can( 'edit_user', $user->ID ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view the meta for this user.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
@@ -92,20 +85,13 @@ class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function delete_item_permissions_check( $request ) {
-		$parent = get_user_by( 'id', (int) $request['parent_id'] );
+		$user = get_user_by( 'id', (int) $request['parent_id'] );
 
-		if ( empty( $parent ) || empty( $parent->ID ) ) {
+		if ( empty( $user ) || empty( $user->ID ) ) {
 			return new WP_Error( 'rest_user_invalid_id', __( 'Invalid user id.' ), array( 'status' => 404 ) );
 		}
 
-		/* @todo Add a new check to read user
-
-		if ( ! $this->parent_controller->check_read_permission( $parent ) ) {
-			return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view this user.' ), array( 'status' => rest_authorization_required_code() ) );
-		}
-		*/
-
-		if ( ! current_user_can( 'delete_user', $parent->ID ) ) {
+		if ( ! current_user_can( 'delete_user', $user->ID ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot delete the meta for this user.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;

--- a/lib/class-wp-rest-meta-users-controller.php
+++ b/lib/class-wp-rest-meta-users-controller.php
@@ -36,7 +36,7 @@ class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function get_items_permissions_check( $request ) {
-		$parent = get_post( (int) $request['parent_id'] );
+		$parent = get_user_by( 'id', (int) $request['parent_id'] );
 
 		if ( empty( $parent ) || empty( $parent->ID ) ) {
 			return new WP_Error( 'rest_user_invalid_id', __( 'Invalid user id.' ), array( 'status' => 404 ) );
@@ -92,7 +92,7 @@ class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function delete_item_permissions_check( $request ) {
-		$parent = get_post( (int) $request['parent_id'] );
+		$parent = get_user_by( 'id', (int) $request['parent_id'] );
 
 		if ( empty( $parent ) || empty( $parent->ID ) ) {
 			return new WP_Error( 'rest_user_invalid_id', __( 'Invalid user id.' ), array( 'status' => 404 ) );
@@ -105,7 +105,7 @@ class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
 		}
 		*/
 
-		if ( ! current_user_can( 'edit_users', $parent->ID ) ) {
+		if ( ! current_user_can( 'delete_users', $parent->ID ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot delete the meta for this user.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;

--- a/lib/class-wp-rest-meta-users-controller.php
+++ b/lib/class-wp-rest-meta-users-controller.php
@@ -1,0 +1,113 @@
+<?php
+
+class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
+
+	/**
+	 * Associated object type.
+	 *
+	 * @var string Type slug ("post", "user", or "comment")
+	 */
+	protected $parent_type = 'user';
+
+	/**
+	 * Base path for parent meta type endpoints.
+	 *
+	 * @var string
+	 */
+	protected $parent_base = 'users';
+
+	/**
+	 * User controller class object.
+	 *
+	 * @var WP_REST_Users_Controller
+	 */
+	protected $parent_controller;
+
+	public function __construct() {
+		$this->parent_controller = new WP_REST_Users_Controller();
+		$this->namespace = 'wp/v2';
+		$this->rest_base = 'meta';
+	}
+
+	/**
+	 * Check if a given request has access to get meta for a post.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		$parent = get_post( (int) $request['parent_id'] );
+
+		if ( empty( $parent ) || empty( $parent->ID ) ) {
+			return new WP_Error( 'rest_user_invalid_id', __( 'Invalid user id.' ), array( 'status' => 404 ) );
+		}
+
+		/* @todo Add a new check to read user
+
+		if ( ! $this->parent_controller->check_read_permission( $parent ) ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view this user.' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		*/
+
+		if ( ! current_user_can( 'edit_users', $parent->ID ) ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view the meta for this user.' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to get a specific meta entry for a post.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		return $this->get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Check if a given request has access to create a meta entry for a post.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function create_item_permissions_check( $request ) {
+		return $this->get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Check if a given request has access to update a meta entry for a post.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function update_item_permissions_check( $request ) {
+		return $this->get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Check if a given request has access to delete meta for a post.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function delete_item_permissions_check( $request ) {
+		$parent = get_post( (int) $request['parent_id'] );
+
+		if ( empty( $parent ) || empty( $parent->ID ) ) {
+			return new WP_Error( 'rest_user_invalid_id', __( 'Invalid user id.' ), array( 'status' => 404 ) );
+		}
+
+		/* @todo Add a new check to read user
+
+		if ( ! $this->parent_controller->check_read_permission( $parent ) ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view this user.' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		*/
+
+		if ( ! current_user_can( 'edit_users', $parent->ID ) ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot delete the meta for this user.' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+}

--- a/lib/class-wp-rest-meta-users-controller.php
+++ b/lib/class-wp-rest-meta-users-controller.php
@@ -30,7 +30,7 @@ class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to get meta for a post.
+	 * Check if a given request has access to get meta for a user.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|boolean
@@ -56,7 +56,7 @@ class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to get a specific meta entry for a post.
+	 * Check if a given request has access to get a specific meta entry for a user.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|boolean
@@ -66,7 +66,7 @@ class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to create a meta entry for a post.
+	 * Check if a given request has access to create a meta entry for a user.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|boolean
@@ -76,7 +76,7 @@ class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to update a meta entry for a post.
+	 * Check if a given request has access to update a meta entry for a user.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|boolean
@@ -86,7 +86,7 @@ class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to delete meta for a post.
+	 * Check if a given request has access to delete meta for a user.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean

--- a/lib/class-wp-rest-meta-users-controller.php
+++ b/lib/class-wp-rest-meta-users-controller.php
@@ -5,14 +5,14 @@ class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
 	/**
 	 * Associated object type.
 	 *
-	 * @var string Type slug ("post", "user", or "comment")
+	 * @var string "user"
 	 */
 	protected $parent_type = 'user';
 
 	/**
 	 * Base path for parent meta type endpoints.
 	 *
-	 * @var string
+	 * @var string "users"
 	 */
 	protected $parent_base = 'users';
 
@@ -49,7 +49,7 @@ class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
 		}
 		*/
 
-		if ( ! current_user_can( 'edit_users', $parent->ID ) ) {
+		if ( ! current_user_can( 'edit_user', $parent->ID ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view the meta for this user.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
@@ -105,7 +105,7 @@ class WP_REST_Meta_Users_Controller extends WP_REST_Meta_Controller {
 		}
 		*/
 
-		if ( ! current_user_can( 'delete_users', $parent->ID ) ) {
+		if ( ! current_user_can( 'delete_user', $parent->ID ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot delete the meta for this user.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;

--- a/plugin.php
+++ b/plugin.php
@@ -21,12 +21,20 @@ function meta_rest_api_init() {
 		require_once dirname( __FILE__ ) . '/lib/class-wp-rest-meta-posts-controller.php';
 	}
 
+	if ( class_exists( 'WP_REST_Controller' )
+		&& ! class_exists( 'WP_REST_Meta_Users_Controller' ) ) {
+		require_once dirname( __FILE__ ) . '/lib/class-wp-rest-meta-users-controller.php';
+	}
+
 	foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
 		if ( post_type_supports( $post_type->name, 'custom-fields' ) ) {
 			$meta_controller = new WP_REST_Meta_Posts_Controller( $post_type->name );
 			$meta_controller->register_routes();
 		}
 	}
+
+	$user_meta_controller = new WP_REST_Meta_Users_Controller();
+	$user_meta_controller->register_routes();
 }
 
 add_action( 'rest_api_init', 'meta_rest_api_init', 11 );

--- a/tests/test-rest-meta-users-controller.php
+++ b/tests/test-rest-meta-users-controller.php
@@ -10,12 +10,9 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 	public function setUp() {
 		parent::setUp();
 
-		$this->user = $this->factory->user->create();
-		wp_set_current_user( $this->user );
-		$this->user_obj = wp_get_current_user();
-		$this->user_obj->add_role( 'adminstrator' );
-		$this->user_obj->add_cap( 'edit_users' );
-		$this->user_obj->add_cap( 'delete_users' );
+		$this->user = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
 	}
 
 	public function test_register_routes() {
@@ -45,13 +42,14 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_items() {
-		$user_id                    = $this->factory->user->create();
-		$meta_id_serialized         = add_user_meta( $user_id, 'testkey_serialized', array( 'testvalue1', 'testvalue2' ) );
-		$meta_id_serialized_object  = add_user_meta( $user_id, 'testkey_serialized_object', (object) array( 'testvalue' => 'test' ) );
-		$meta_id_serialized_array   = add_user_meta( $user_id, 'testkey_serialized_array', serialize( array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ) ) );
-		$meta_id_protected          = add_user_meta( $user_id, '_testkey', 'testvalue' );
+		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta', $user_id ) );
+		$meta_id_serialized         = add_user_meta( $this->user, 'testkey_serialized', array( 'testvalue1', 'testvalue2' ) );
+		$meta_id_serialized_object  = add_user_meta( $this->user, 'testkey_serialized_object', (object) array( 'testvalue' => 'test' ) );
+		$meta_id_serialized_array   = add_user_meta( $this->user, 'testkey_serialized_array', serialize( array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ) ) );
+		$meta_id_protected          = add_user_meta( $this->user, '_testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );

--- a/tests/test-rest-meta-users-controller.php
+++ b/tests/test-rest-meta-users-controller.php
@@ -43,6 +43,7 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 
 	public function test_get_items() {
 		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
 
 		$meta_id_serialized         = add_user_meta( $this->user, 'testkey_serialized', array( 'testvalue1', 'testvalue2' ) );
 		$meta_id_serialized_object  = add_user_meta( $this->user, 'testkey_serialized_object', (object) array( 'testvalue' => 'test' ) );
@@ -80,6 +81,7 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 
 	public function test_get_item() {
 		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
 
 		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
 
@@ -100,6 +102,7 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 
 	public function test_create_item() {
 		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
 
 		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
 		$request->set_body_params( array(
@@ -121,6 +124,7 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 
 	public function test_update_item() {
 		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
 		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
@@ -145,6 +149,7 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 
 	public function test_delete_item() {
 		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
 		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
 
 		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
@@ -163,6 +168,8 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 
 	public function test_prepare_item() {
 		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		
 		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
 
 		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
@@ -176,5 +183,14 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 
 	public function test_get_item_schema() {
 		// No op
+	}
+
+	protected function allow_user_to_manage_multisite() {
+		wp_set_current_user( $this->user );
+		$user = wp_get_current_user();
+		if ( is_multisite() ) {
+			update_site_option( 'site_admins', array( $user->user_login ) );
+		}
+		return;
 	}
 }

--- a/tests/test-rest-meta-users-controller.php
+++ b/tests/test-rest-meta-users-controller.php
@@ -169,7 +169,7 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_prepare_item() {
 		wp_set_current_user( $this->user );
 		$this->allow_user_to_manage_multisite();
-		
+
 		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
 
 		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );

--- a/tests/test-rest-meta-users-controller.php
+++ b/tests/test-rest-meta-users-controller.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Unit tests covering WP_REST_Users meta functionality.
+ *
+ * @package WordPress
+ * @subpackage JSON API
+ */
+class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcase {
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create();
+		wp_set_current_user( $this->user );
+		$this->user_obj = wp_get_current_user();
+		$this->user_obj->add_role( 'adminstrator' );
+		$this->user_obj->add_cap( 'edit_users' );
+		$this->user_obj->add_cap( 'delete_users' );
+	}
+
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( '/wp/v2/users/(?P<parent_id>[\d]+)/meta', $routes );
+		$this->assertCount( 2, $routes['/wp/v2/users/(?P<parent_id>[\d]+)/meta'] );
+		$this->assertArrayHasKey( '/wp/v2/users/(?P<parent_id>[\d]+)/meta/(?P<id>[\d]+)', $routes );
+		$this->assertCount( 3, $routes['/wp/v2/users/(?P<parent_id>[\d]+)/meta/(?P<id>[\d]+)'] );
+	}
+
+	public function test_context_param() {
+		$user_id = $this->factory->user->create();
+		// Collection
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users/' . $user_id . '/meta' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'edit', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single
+		$meta_id_basic = add_user_meta( $user_id, 'testkey', 'testvalue' );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users/' . $user_id . '/meta/' . $meta_id_basic );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'edit', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
+	public function test_get_items() {
+		$user_id                    = $this->factory->user->create();
+		$meta_id_serialized         = add_user_meta( $user_id, 'testkey_serialized', array( 'testvalue1', 'testvalue2' ) );
+		$meta_id_serialized_object  = add_user_meta( $user_id, 'testkey_serialized_object', (object) array( 'testvalue' => 'test' ) );
+		$meta_id_serialized_array   = add_user_meta( $user_id, 'testkey_serialized_array', serialize( array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ) ) );
+		$meta_id_protected          = add_user_meta( $user_id, '_testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta', $user_id ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		foreach ( $data as $row ) {
+			$row = (array) $row;
+			$this->assertArrayHasKey( 'id', $row );
+			$this->assertArrayHasKey( 'key', $row );
+			$this->assertArrayHasKey( 'value', $row );
+
+			if ( $row['id'] === $meta_id_serialized ) {
+				$this->assertEquals( 'testkey_serialized', $row['key'] );
+				$this->assertEquals( array( 'testvalue1', 'testvalue2' ), $row['value'] );
+			}
+
+			if ( $row['id'] === $meta_id_serialized_object ) {
+				$this->assertEquals( 'testkey_serialized_object', $row['key'] );
+				$this->assertEquals( (object) array( 'testvalue' => 'test' ), $row['value'] );
+			}
+
+			if ( $row['id'] === $meta_id_serialized_array ) {
+				$this->assertEquals( 'testkey_serialized_array', $row['key'] );
+				$this->assertEquals( serialize( array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ) ), $row['value'] );
+			}
+		}
+	}
+
+	public function test_get_item() {
+		// No op
+	}
+
+	public function test_create_item() {
+		// No op
+	}
+
+	public function test_update_item() {
+		// No op
+	}
+
+	public function test_delete_item() {
+		// No op
+	}
+
+	public function test_prepare_item() {
+		// No op
+	}
+
+	public function test_get_item_schema() {
+		// No op
+	}
+}

--- a/tests/test-rest-meta-users-controller.php
+++ b/tests/test-rest-meta-users-controller.php
@@ -102,7 +102,7 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 
 	public function test_get_item_no_user_id() {
 		wp_set_current_user( $this->user );
-$this->allow_user_to_manage_multisite();
+		$this->allow_user_to_manage_multisite();
 		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
 
 		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );

--- a/tests/test-rest-meta-users-controller.php
+++ b/tests/test-rest-meta-users-controller.php
@@ -25,20 +25,41 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_context_param() {
-		$user_id = $this->factory->user->create();
+		$this->user = $this->factory->user->create();
 		// Collection
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users/' . $user_id . '/meta' );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users/' . $this->user . '/meta' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'edit', $data['endpoints'][0]['args']['context']['default'] );
 		$this->assertEquals( array( 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 		// Single
-		$meta_id_basic = add_user_meta( $user_id, 'testkey', 'testvalue' );
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users/' . $user_id . '/meta/' . $meta_id_basic );
+		$meta_id_basic = add_user_meta( $this->user, 'testkey', 'testvalue' );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users/' . $this->user . '/meta/' . $meta_id_basic );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'edit', $data['endpoints'][0]['args']['context']['default'] );
 		$this->assertEquals( array( 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
+	public function test_get_item() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertCount( 3, $data );
+
+		if ( $data['id'] === $meta_id ) {
+			$this->assertEquals( 'testkey', $data['key'] );
+			$this->assertEquals( 'testvalue', $data['value'] );
+		} else {
+			$this->fail();
+		}
 	}
 
 	public function test_get_items() {
@@ -79,25 +100,144 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 		}
 	}
 
-	public function test_get_item() {
+	public function test_get_item_no_user_id() {
 		wp_set_current_user( $this->user );
-		$this->allow_user_to_manage_multisite();
-
+$this->allow_user_to_manage_multisite();
 		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
 
 		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request['parent_id'] = 0;
+
 		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_user_invalid_id', $response, 404 );
+	}
 
-		$this->assertEquals( 200, $response->get_status() );
-		$data = $response->get_data();
-		$this->assertCount( 3, $data );
+	public function test_get_item_invalid_user_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
 
-		if ( $data['id'] === $meta_id ) {
-			$this->assertEquals( 'testkey', $data['key'] );
-			$this->assertEquals( 'testvalue', $data['value'] );
-		} else {
-			$this->fail();
-		}
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request['parent_id'] = -1;
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_user_invalid_id', $response, 404 );
+	}
+
+	public function test_get_item_no_meta_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', 0, $meta_id ) );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_user_invalid_id', $response, 404 );
+	}
+
+	public function test_get_item_invalid_meta_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request['id'] = 'a';
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_id', $response, 404 );
+	}
+
+	public function test_get_item_protected() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, '_testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_protected', $response, 403 );
+	}
+
+	public function test_get_item_serialized_array() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', array( 'testvalue' => 'test' ) );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_protected', $response, 403 );
+	}
+
+	public function test_get_item_serialized_object() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', (object) array( 'testvalue' => 'test' ) );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_protected', $response, 403 );
+	}
+
+	public function test_get_item_unauthenticated() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+	}
+
+	public function test_get_item_wrong_user() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$this->user_two = $this->factory->user->create();
+		$meta_id_two = add_user_meta( $this->user_two, 'testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', $this->user_two, $meta_id ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_user_mismatch', $response, 400 );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id_two ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_user_mismatch', $response, 400 );
+	}
+
+	public function test_get_items_no_user_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request['parent_id'] = 0;
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_user_invalid_id', $response );
+	}
+
+	public function test_get_items_invalid_user_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request['parent_id'] = -1;
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_user_invalid_id', $response );
+	}
+
+	public function test_get_items_unauthenticated() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_forbidden', $response );
 	}
 
 	public function test_create_item() {
@@ -120,6 +260,241 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertArrayHasKey( 'id', $data );
 		$this->assertEquals( 'testkey', $data['key'] );
 		$this->assertEquals( 'testvalue', $data['value'] );
+	}
+
+	public function test_create_item_no_user_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'key' => 'testkey',
+			'value' => 'testvalue',
+		);
+
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request->set_body_params( $data );
+
+		$request['parent_id'] = 0;
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_user_invalid_id', $response, 404 );
+	}
+
+	public function test_create_item_invalid_user_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'key' => 'testkey',
+			'value' => 'testvalue',
+		);
+
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request->set_body_params( $data );
+
+		$request['parent_id'] = -1;
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_user_invalid_id', $response, 404 );
+	}
+
+	public function test_create_item_no_value() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'key' => 'testkey',
+		);
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertEquals( 'testkey', $data['key'] );
+		$this->assertEquals( '', $data['value'] );
+	}
+
+	public function test_create_item_no_key() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'value' => 'testvalue',
+		);
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_missing_callback_param', $response, 400 );
+	}
+
+	public function test_create_item_empty_string_key() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'key' => '',
+			'value' => 'testvalue',
+		);
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_key', $response, 400 );
+	}
+
+	public function test_create_item_invalid_key() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'key' => false,
+			'value' => 'testvalue',
+		);
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_key', $response, 400 );
+	}
+
+	public function test_create_item_unauthenticated() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'key' => 'testkey',
+			'value' => 'testvalue',
+		);
+
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+		$this->assertEmpty( get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_create_item_serialized_array() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'key' => 'testkey',
+			'value' => array( 'testvalue1', 'testvalue2' ),
+		);
+
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+		$this->assertEmpty( get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_create_item_serialized_object() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'key' => 'testkey',
+			'value' => (object) array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ),
+		);
+
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+		$this->assertEmpty( get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_create_item_serialized_string() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'key' => 'testkey',
+			'value' => serialize( array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ) ),
+		);
+
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_action', $response, 400 );
+		$this->assertEmpty( get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_create_item_failed_get() {
+		$this->markTestSkipped();
+
+		$this->endpoint = $this->getMock( 'WP_REST_Meta_Posts', array( 'get_meta' ), array( $this->fake_server ) );
+
+		$test_error = new WP_Error( 'rest_test_error', 'Test error' );
+		$this->endpoint->expects( $this->any() )->method( 'get_meta' )->will( $this->returnValue( $test_error ) );
+
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'key' => 'testkey',
+			'value' => 'testvalue',
+		);
+
+		$response = $this->endpoint->add_meta( $this->user, $data );
+		$this->assertErrorResponse( 'rest_test_error', $response );
+	}
+
+	public function test_create_item_protected() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'key' => '_testkey',
+			'value' => 'testvalue',
+		);
+
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_protected', $response, 403 );
+		$this->assertEmpty( get_user_meta( $this->user, '_testkey' ) );
+	}
+
+	/**
+	 * Ensure slashes aren't added
+	 */
+	public function test_create_item_unslashed() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'key' => 'testkey',
+			'value' => "test unslashed ' value",
+		);
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request->set_body_params( $data );
+
+		$this->server->dispatch( $request );
+
+		$meta = get_user_meta( $this->user, 'testkey', false );
+		$this->assertNotEmpty( $meta );
+		$this->assertCount( 1, $meta );
+		$this->assertEquals( "test unslashed ' value", $meta[0] );
+	}
+
+	/**
+	 * Ensure slashes aren't touched in data
+	 */
+	public function test_create_item_slashed() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$data = array(
+			'key' => 'testkey',
+			'value' => "test slashed \\' value",
+		);
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta', $this->user ) );
+		$request->set_body_params( $data );
+
+		$this->server->dispatch( $request );
+
+		$meta = get_user_meta( $this->user, 'testkey', false );
+		$this->assertNotEmpty( $meta );
+		$this->assertCount( 1, $meta );
+		$this->assertEquals( "test slashed \\' value", $meta[0] );
 	}
 
 	public function test_update_item() {
@@ -147,6 +522,354 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertEquals( 'testnewvalue', $meta[0] );
 	}
 
+	public function test_update_meta_key() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array(
+			'key' => 'testnewkey',
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEquals( $meta_id, $data['id'] );
+		$this->assertEquals( 'testnewkey', $data['key'] );
+		$this->assertEquals( 'testvalue', $data['value'] );
+
+		$meta = get_user_meta( $this->user, 'testnewkey', false );
+		$this->assertNotEmpty( $meta );
+		$this->assertCount( 1, $meta );
+		$this->assertEquals( 'testvalue', $meta[0] );
+
+		// Ensure it was actually renamed, not created
+		$meta = get_user_meta( $this->user, 'testkey', false );
+		$this->assertEmpty( $meta );
+	}
+
+	public function test_update_meta_key_and_value() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array(
+			'key' => 'testnewkey',
+			'value' => 'testnewvalue',
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEquals( $meta_id, $data['id'] );
+		$this->assertEquals( 'testnewkey', $data['key'] );
+		$this->assertEquals( 'testnewvalue', $data['value'] );
+
+		$meta = get_user_meta( $this->user, 'testnewkey', false );
+		$this->assertNotEmpty( $meta );
+		$this->assertCount( 1, $meta );
+		$this->assertEquals( 'testnewvalue', $meta[0] );
+
+		// Ensure it was actually renamed, not created
+		$meta = get_user_meta( $this->user, 'testkey', false );
+		$this->assertEmpty( $meta );
+	}
+
+	public function test_update_meta_empty() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array();
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_data_invalid', $response, 400 );
+	}
+
+	public function test_update_meta_no_user_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array(
+			'key' => 'testnewkey',
+			'value' => 'testnewvalue',
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', 0, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_user_invalid_id', $response, 404 );
+	}
+
+	public function test_update_meta_invalid_user_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array(
+			'key' => 'testnewkey',
+			'value' => 'testnewvalue',
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_user_invalid_id', $response, 404 );
+	}
+
+	public function test_update_meta_no_meta_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array(
+			'key' => 'testnewkey',
+			'value' => 'testnewvalue',
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, 0 ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_id', $response, 404 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_update_meta_invalid_meta_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array(
+			'key' => 'testnewkey',
+			'value' => 'testnewvalue',
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request['id'] = 'a';
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_id', $response, 404 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_update_meta_unauthenticated() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		wp_set_current_user( 0 );
+
+		$data = array(
+			'key' => 'testnewkey',
+			'value' => 'testnewvalue',
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_update_meta_wrong_user() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$this->user_two = $this->factory->user->create();
+		$meta_id_two = add_user_meta( $this->user_two, 'testkey', 'testvalue' );
+
+		$data = array(
+			'key' => 'testnewkey',
+			'value' => 'testnewvalue',
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user_two, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_user_mismatch', $response, 400 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user_two, 'testkey' ) );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id_two ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_user_mismatch', $response, 400 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_update_meta_serialized_array() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array(
+			'value' => array( 'testvalue1', 'testvalue2' ),
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_update_meta_serialized_object() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array(
+			'value' => (object) array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ),
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_update_meta_serialized_string() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array(
+			'value' => serialize( array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ) ),
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_action', $response, 400 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_update_meta_existing_serialized() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', array( 'testvalue1', 'testvalue2' ) );
+
+		$data = array(
+			'value' => 'testnewvalue',
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_action', $response, 400 );
+		$this->assertEquals( array( array( 'testvalue1', 'testvalue2' ) ), get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_update_meta_protected() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, '_testkey', 'testvalue' );
+
+		$data = array(
+			'value' => 'testnewvalue',
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_protected', $response, 403 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, '_testkey' ) );
+	}
+
+	public function test_update_meta_protected_new() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array(
+			'key' => '_testnewkey',
+			'value' => 'testnewvalue',
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_protected', $response, 403 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey' ) );
+		$this->assertEmpty( get_user_meta( $this->user, '_testnewkey' ) );
+	}
+
+	public function test_update_meta_invalid_key() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array(
+			'key' => false,
+			'value' => 'testnewvalue',
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_key', $response, 400 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	/**
+	 * Ensure slashes aren't added
+	 */
+	public function test_update_meta_unslashed() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array(
+			'key' => 'testkey',
+			'value' => "test unslashed ' value",
+		);
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$this->server->dispatch( $request );
+
+		$meta = get_user_meta( $this->user, 'testkey', false );
+		$this->assertNotEmpty( $meta );
+		$this->assertCount( 1, $meta );
+		$this->assertEquals( "test unslashed ' value", $meta[0] );
+	}
+
+	/**
+	 * Ensure slashes aren't touched in data
+	 */
+	public function test_update_meta_slashed() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$data = array(
+			'key' => 'testkey',
+			'value' => "test slashed \\' value",
+		);
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request->set_body_params( $data );
+
+		$this->server->dispatch( $request );
+
+		$meta = get_user_meta( $this->user, 'testkey', false );
+		$this->assertNotEmpty( $meta );
+		$this->assertCount( 1, $meta );
+		$this->assertEquals( "test slashed \\' value", $meta[0] );
+	}
+
 	public function test_delete_item() {
 		wp_set_current_user( $this->user );
 		$this->allow_user_to_manage_multisite();
@@ -164,6 +887,174 @@ class WP_Test_REST_Meta_Users_Controller extends WP_Test_REST_Controller_Testcas
 
 		$meta = get_user_meta( $this->user, 'testkey', false );
 		$this->assertEmpty( $meta );
+	}
+
+	public function test_delete_item_no_trash() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_trash_not_supported', $response, 501 );
+
+		// Ensure the meta still exists
+		$meta = get_metadata_by_mid( 'user', $meta_id );
+		$this->assertNotEmpty( $meta );
+	}
+
+	public function test_delete_item_no_user_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request['force'] = true;
+		$request['parent_id'] = 0;
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_user_invalid_id', $response, 404 );
+
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey', false ) );
+	}
+
+	public function test_delete_item_invalid_user_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request['force'] = true;
+		$request['parent_id'] = -1;
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_user_invalid_id', $response, 404 );
+
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey', false ) );
+	}
+
+	public function test_delete_item_no_meta_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request['force'] = true;
+		$request['id'] = 0;
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_id', $response, 404 );
+
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey', false ) );
+	}
+
+	public function test_delete_item_invalid_meta_id() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request['force'] = true;
+		$request['id'] = 'a';
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_id', $response, 404 );
+
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey', false ) );
+	}
+
+	public function test_delete_item_unauthenticated() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request['force'] = true;
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey', false ) );
+	}
+
+	public function test_delete_item_wrong_user() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, 'testkey', 'testvalue' );
+
+		$this->user_two = $this->factory->user->create();
+		$meta_id_two = add_user_meta( $this->user_two, 'testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d/meta/%d', $this->user_two, $meta_id ) );
+		$request['force'] = true;
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_user_mismatch', $response, 400 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user_two, 'testkey' ) );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id_two ) );
+		$request['force'] = true;
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_user_mismatch', $response, 400 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_delete_item_serialized_array() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$value = array( 'testvalue1', 'testvalue2' );
+		$meta_id = add_user_meta( $this->user, 'testkey', $value );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request['force'] = true;
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_action', $response, 400 );
+		$this->assertEquals( array( $value ), get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_delete_item_serialized_object() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$value = (object) array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' );
+		$meta_id = add_user_meta( $this->user, 'testkey', $value );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request['force'] = true;
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_action', $response, 400 );
+		$this->assertEquals( array( $value ), get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_delete_item_serialized_string() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$value = serialize( array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ) );
+		$meta_id = add_user_meta( $this->user, 'testkey', $value );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request['force'] = true;
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_action', $response, 400 );
+		$this->assertEquals( array( $value ), get_user_meta( $this->user, 'testkey' ) );
+	}
+
+	public function test_delete_item_protected() {
+		wp_set_current_user( $this->user );
+		$this->allow_user_to_manage_multisite();
+		$meta_id = add_user_meta( $this->user, '_testkey', 'testvalue' );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d/meta/%d', $this->user, $meta_id ) );
+		$request['force'] = true;
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_protected', $response, 403 );
+		$this->assertEquals( array( 'testvalue' ), get_user_meta( $this->user, '_testkey' ) );
 	}
 
 	public function test_prepare_item() {


### PR DESCRIPTION
I wanted to learn more about the Rest API so I decided to take a crack at adding the User meta endpoints based on this issue https://github.com/WP-API/wp-api-meta-endpoints/issues/1.  I love how you made the WP_REST_Meta_Controller class by the way.

One thing that I was not sure about how to do was the `check_read_permission` authorization check.  This is just a different use case from posts I think since we are displaying user data rather than post data, so wouldn't that data never be shown to logged out users? @danielbachhuber...or am I just overthinking it :)

For now the `check_read_permission` function is commented out with `@todo` placed above it.  I have not added in the unit tests yet.
