### PR TITLE
Update Composer installer path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "wp-coding-standards/wpcs": "0.6.0"
     },
     "extra": {
-        "installer-name": "json-rest-api"
+        "installer-name": "json-rest-api-meta-endpoints"
     },
     "scripts": {
         "post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths vendor/wp-coding-standards/wpcs",


### PR DESCRIPTION
This prevents a conflict with the core `wp-api` package when both plugins are installed via Composer. Without the change this plugin will overwrite `wp-api` in the `json-rest-api` folder.
